### PR TITLE
Move to Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: Build and Deploy Website
+on:
+  push:
+    branches:
+      - master
+      - d3-pre-deploy
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-18.04
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+
+      - name: Pull cache if available
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: bundle-use-ruby-2.6-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            bundle-use-ruby-2.6-
+
+      - name: bundle install
+        run: |
+          bundle config deployment true
+          bundle config path vendor/bundle
+          bundle install --jobs 4
+
+      - name: Build the page
+        run: bundle exec jekyll build
+
+      - name: Push to GH Pages
+        uses: JamesIves/github-pages-deploy-action@3.5.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: _site

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.4.2)
+    activesupport (5.2.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -73,7 +73,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
     mini_portile2 (2.4.0)
-    minitest (5.14.0)
+    minitest (5.14.1)
     multi_json (1.14.1)
     multipart-post (2.1.1)
     nokogiri (1.10.9)
@@ -86,7 +86,7 @@ GEM
     public_suffix (4.0.3)
     pygments.rb (1.2.1)
       multi_json (>= 1.0.0)
-    rack (2.2.2)
+    rack (2.2.3)
     rake (13.0.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
@@ -108,7 +108,7 @@ GEM
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     thread_safe (0.3.6)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)


### PR DESCRIPTION
We had an issue where the default Github build started behaving
differently, so we'd like to pin our versions. This commit will
have Github Actions do the build against our Gemfile.lock.

Note that the effects of this commit on the actual deployed website
*will not take effect* until the Github settings are changed to
reflect that the site is now hosted on the gh-pages branch.

This also upgrades `rack` and `activesupport` which Github keeps
complaining have security issues.